### PR TITLE
Add Physical Review Journals tex template

### DIFF
--- a/data/tex.yml
+++ b/data/tex.yml
@@ -52,3 +52,7 @@ templates:
     name: lapreprint
     source: https://github.com/myst-templates/lapreprint
     latest: main
+  - organization: dressedfez
+    name: physical_review_journals
+    source: https://github.com/dressedfez/myst_template_physical_review_journals
+    latest: main


### PR DESCRIPTION
This provides the initial version of the LaTex template for Physical Review Journal articles associated to the
American Physical Society (see https://journals.aps.org/about). 
