### PR TITLE
Add LePub

### DIFF
--- a/data/typst.yml
+++ b/data/typst.yml
@@ -8,3 +8,7 @@ templates:
     name: lapreprint-typst
     source: https://github.com/myst-templates/lapreprint-typst
     latest: main
+  - organization: LaPreprint
+    name: lepub-typst
+    source: https://github.com/lapreprint/lepub/myst
+    latest: main


### PR DESCRIPTION
I've got two questions in relation to this addition:

1. Is it necessary to have `typst` prepended? (`lepub-typst`) 
2. Can it access a folder within the repo? This MyST-friendly template lives in the `myst` folder inside the project, so I have specified that in the URL.
 