### PR TITLE
Add preprint+ template

### DIFF
--- a/data/tex.yml
+++ b/data/tex.yml
@@ -72,3 +72,7 @@ templates:
     name: springer
     source: https://github.com/myst-templates/springer
     latest: main 
+  - organization: alcrene
+    name: preprint+
+    source: https://github.com/alcrene/myst-preprint-plus
+    latest: main


### PR DESCRIPTION
This template is based on the one I hacked together to write my recent Nature Communications paper.

The basic idea was to take *arxiv_two_column*, but make the hard-coded design choices configurable.
Along the way I also added features I needed, such as support for Supplementary Material.

In the process I ended completely [rewriting](https://github.com/alcrene/latex-preprint-plus) the underlying `preprint.sty` style file to LaTeX3, which I called `preprint+.sty`