### PR TITLE
Add STEM Lecture Notes Typst template

### DIFF
--- a/data/typst.yml
+++ b/data/typst.yml
@@ -16,3 +16,7 @@ templates:
     name: letterloom-typst
     source: https://github.com/stefanv/myst-typst-letterloom
     latest: main
+  - organization: NitraxMathematicalKeyboard
+    name: stem-lecture-notes
+    source: https://github.com/NitraxMathematicalKeyboard/stem-lecture-notes-myst
+    latest: main


### PR DESCRIPTION
## Summary

Adds the open-source stem-lecture-notes Typst template to the community index.

## Template

- Source: https://github.com/NitraxMathematicalKeyboard/stem-lecture-notes-myst
- Engine: Typst
- License: MIT
- Intended use: STEM lecture notes, course handouts, scientific memos, and exam review sheets
- Formats tested: A4 and US Letter

## Validation

- 	emplate.yml validated with the current myst-templates schema
- Official index command completed successfully for data/typst.yml
- Example exports build with MyST 1.10.1 and Typst 0.15.0 in strict CI mode
- Equations, cross-references, citations, bibliography, figures, tables, proof blocks, exercises, solutions, code, and footnotes are covered by the example